### PR TITLE
Utility classes should not have public constructors

### DIFF
--- a/blockcanary-core/src/main/java/com/github/moduth/blockcanary/HandlerThread.java
+++ b/blockcanary-core/src/main/java/com/github/moduth/blockcanary/HandlerThread.java
@@ -12,6 +12,10 @@ class HandlerThread {
     private static HandlerThreadWrapper sLoopThread = new HandlerThreadWrapper("loop");
     private static HandlerThreadWrapper sWriteLogThread = new HandlerThreadWrapper("writelog");
 
+    private HandlerThread() {
+        throw new InstantiationError("Must not instantiate this class");
+    }
+
     /**
      * Get handler of looper thread
      */

--- a/blockcanary-core/src/main/java/com/github/moduth/blockcanary/LogWriter.java
+++ b/blockcanary-core/src/main/java/com/github/moduth/blockcanary/LogWriter.java
@@ -37,13 +37,17 @@ public class LogWriter {
     private static final SimpleDateFormat TIME_FORMATTER = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
     private static final long OBSOLETE_DURATION = 2 * 24 * 3600 * 1000;
 
+    private LogWriter() {
+        throw new InstantiationError("Must not instantiate this class");
+    }
+
     /**
      * Save log to file
      *
      * @param str block log string
      * @return log file path
      */
-    public static String saveLooperLog(String str) {
+	public static String saveLooperLog(String str) {
         String path;
         synchronized (SAVE_DELETE_LOCK) {
             path = saveLogToSDCard("looper", str);

--- a/blockcanary-core/src/main/java/com/github/moduth/blockcanary/UploadMonitorLog.java
+++ b/blockcanary-core/src/main/java/com/github/moduth/blockcanary/UploadMonitorLog.java
@@ -31,6 +31,10 @@ class UploadMonitorLog {
     private static final String TAG = "UploadMonitorLog";
     private static final SimpleDateFormat FORMAT = new SimpleDateFormat("yyyy-MM-dd-HH-mm-ss");
 
+    private UploadMonitorLog() {
+        throw new InstantiationError("Must not instantiate this class");
+    }
+
     private static File zipFile() {
         String timeString = System.currentTimeMillis() + "";
         try {

--- a/blockcanary-core/src/main/java/com/github/moduth/blockcanary/log/PerformanceUtils.java
+++ b/blockcanary-core/src/main/java/com/github/moduth/blockcanary/log/PerformanceUtils.java
@@ -32,6 +32,10 @@ public class PerformanceUtils {
     private static int sCoreNum = 0;
     private static long sTotalMemo = 0;
 
+    private PerformanceUtils() {
+        throw new InstantiationError("Must not instantiate this class");
+    }
+
     /**
      * Get cpu core number
      *

--- a/blockcanary-core/src/main/java/com/github/moduth/blockcanary/log/ProcessUtils.java
+++ b/blockcanary-core/src/main/java/com/github/moduth/blockcanary/log/ProcessUtils.java
@@ -25,6 +25,10 @@ public class ProcessUtils {
     private static volatile String sProcessName;
     private final static Object sNameLock = new Object();
 
+    private ProcessUtils() {
+        throw new InstantiationError("Must not instantiate this class");
+    }
+
     public static String myProcessName() {
         if (sProcessName != null) {
             return sProcessName;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1118 Utility classes should not have public constructors

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.

Zeeshan Asghar