### PR TITLE
The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/blockcanary-core/src/main/java/com/github/moduth/blockcanary/log/BlockCanaryInternals.java
+++ b/blockcanary-core/src/main/java/com/github/moduth/blockcanary/log/BlockCanaryInternals.java
@@ -23,6 +23,10 @@ import java.io.FilenameFilter;
  */
 public final class BlockCanaryInternals {
 
+    private BlockCanaryInternals() {
+        throw new AssertionError();
+    }
+
     public static String getPath() {
         String state = android.os.Environment.getExternalStorageState();
         if (android.os.Environment.MEDIA_MOUNTED.equals(state)) {
@@ -48,10 +52,6 @@ public final class BlockCanaryInternals {
             return f.listFiles(new BlockLogFileFilter());
         }
         return null;
-    }
-
-    private BlockCanaryInternals() {
-        throw new AssertionError();
     }
 
     static class BlockLogFileFilter implements FilenameFilter {

--- a/blockcanary-ui/src/main/java/com/github/moduth/blockcanary/ui/BlockDetailAdapter.java
+++ b/blockcanary-ui/src/main/java/com/github/moduth/blockcanary/ui/BlockDetailAdapter.java
@@ -40,6 +40,7 @@ final class BlockDetailAdapter extends BaseAdapter {
 
     private boolean[] mFoldings = new boolean[0];
 
+    private String mStackFoldPrefix = null;
     private Block mBlock;
 
     private static final int POSITION_BASIC = 1;
@@ -192,8 +193,6 @@ final class BlockDetailAdapter extends BaseAdapter {
     private static <T extends View> T findById(View view, int id) {
         return (T) view.findViewById(id);
     }
-
-    private String mStackFoldPrefix = null;
 
     private String getStackFoldPrefix() {
         if (mStackFoldPrefix == null) {

--- a/blockcanary-ui/src/main/java/com/github/moduth/blockcanary/ui/DisplayBlockActivity.java
+++ b/blockcanary-ui/src/main/java/com/github/moduth/blockcanary/ui/DisplayBlockActivity.java
@@ -67,6 +67,14 @@ public class DisplayBlockActivity extends Activity {
     private static final String TAG = "DisplayBlockActivity";
     private static final String SHOW_BLOCK_EXTRA = "show_latest";
     public static final String SHOW_BLOCK_EXTRA_KEY = "BlockStartTime";
+    // null until it's been first loaded.
+    private List<Block> mBlockEntries = new ArrayList<>();
+    private String mBlockStartTime;
+
+    private ListView mListView;
+    private TextView mFailureView;
+    private Button mActionButton;
+    private int mMaxStoredBlockCount;
 
     public static PendingIntent createPendingIntent(Context context) {
         return createPendingIntent(context, null);
@@ -78,15 +86,6 @@ public class DisplayBlockActivity extends Activity {
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
         return PendingIntent.getActivity(context, 1, intent, FLAG_UPDATE_CURRENT);
     }
-
-    // null until it's been first loaded.
-    private List<Block> mBlockEntries = new ArrayList<>();
-    private String mBlockStartTime;
-
-    private ListView mListView;
-    private TextView mFailureView;
-    private Button mActionButton;
-    private int mMaxStoredBlockCount;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -364,8 +363,14 @@ public class DisplayBlockActivity extends Activity {
     static class LoadBlocks implements Runnable {
 
         static final List<LoadBlocks> inFlight = new ArrayList<>();
-
         static final Executor backgroundExecutor = Executors.newSingleThreadExecutor();
+        private DisplayBlockActivity activityOrNull;
+        private final Handler mainHandler;
+
+        LoadBlocks(DisplayBlockActivity activity) {
+            this.activityOrNull = activity;
+            mainHandler = new Handler(Looper.getMainLooper());
+        }
 
         static void load(DisplayBlockActivity activity) {
             LoadBlocks loadBlocks = new LoadBlocks(activity);
@@ -378,14 +383,6 @@ public class DisplayBlockActivity extends Activity {
                 loadBlocks.activityOrNull = null;
             }
             inFlight.clear();
-        }
-
-        private DisplayBlockActivity activityOrNull;
-        private final Handler mainHandler;
-
-        LoadBlocks(DisplayBlockActivity activity) {
-            this.activityOrNull = activity;
-            mainHandler = new Handler(Looper.getMainLooper());
         }
 
         @Override

--- a/blockcanary-ui/src/main/java/com/github/moduth/blockcanary/ui/LeakCanaryUi.java
+++ b/blockcanary-ui/src/main/java/com/github/moduth/blockcanary/ui/LeakCanaryUi.java
@@ -30,6 +30,10 @@ final class LeakCanaryUi {
 
     static final PorterDuffXfermode CLEAR_XFER_MODE = new PorterDuffXfermode(CLEAR);
 
+    private LeakCanaryUi() {
+        throw new AssertionError();
+    }
+
     /**
      * Converts from device independent pixels (dp or dip) to
      * device dependent pixels. This method returns the input
@@ -46,9 +50,5 @@ final class LeakCanaryUi {
     static float dpToPixel(float dp, Resources resources) {
         DisplayMetrics metrics = resources.getDisplayMetrics();
         return metrics.density * dp;
-    }
-
-    private LeakCanaryUi() {
-        throw new AssertionError();
     }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1213 The members of an interface declaration or class should appear in a pre-defined order

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213

Please let me know if you have any questions.

Zeeshan Asghar