### PR TITLE
General Code Improvement 1

### DIFF
--- a/blockcanary-core/src/main/java/com/github/moduth/blockcanary/CpuSampler.java
+++ b/blockcanary-core/src/main/java/com/github/moduth/blockcanary/CpuSampler.java
@@ -187,11 +187,11 @@ class CpuSampler extends Sampler {
             StringBuilder sb = new StringBuilder();
             long idleTime = idle - mIdleLast;
             long totalTime = total - mTotalLast;
-            sb.append("cpu:").append((totalTime - idleTime) * 100L / totalTime).append("% ");
-            sb.append("app:").append((appCpuTime - mAppCpuTimeLast) * 100L / totalTime).append("% ");
-            sb.append("[").append("user:").append((user - mUserLast) * 100L / totalTime).append("% ");
-            sb.append("system:").append((system - mSystemLast) * 100L / totalTime).append("% ");
-            sb.append("ioWait:").append((ioWait - mIoWaitLast) * 100L / totalTime).append("% ]");
+            sb.append("cpu:").append((totalTime - idleTime) * 100L / totalTime).append("% ")
+              .append("app:").append((appCpuTime - mAppCpuTimeLast) * 100L / totalTime).append("% ")
+              .append("[").append("user:").append((user - mUserLast) * 100L / totalTime).append("% ")
+              .append("system:").append((system - mSystemLast) * 100L / totalTime).append("% ")
+              .append("ioWait:").append((ioWait - mIoWaitLast) * 100L / totalTime).append("% ]");
             synchronized (mCpuInfoEntries) {
                 mCpuInfoEntries.put(System.currentTimeMillis(), sb.toString());
                 if (mCpuInfoEntries.size() > MAX_ENTRY_COUNT) {

--- a/blockcanary-core/src/main/java/com/github/moduth/blockcanary/UploadMonitorLog.java
+++ b/blockcanary-core/src/main/java/com/github/moduth/blockcanary/UploadMonitorLog.java
@@ -32,7 +32,7 @@ class UploadMonitorLog {
     private static final SimpleDateFormat FORMAT = new SimpleDateFormat("yyyy-MM-dd-HH-mm-ss");
 
     private static File zipFile() {
-        String timeString = System.currentTimeMillis() + "";
+        String timeString = Long.toString(System.currentTimeMillis());
         try {
             timeString = FORMAT.format(new Date());
         } catch (Throwable e) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S2131 Primitives should not be boxed just for 'String' conversion
pmd:ConsecutiveAppendsShouldReuse Consecutive Appends Should Reuse

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2131
https://dev.eclipse.org/sonar/rules/show/pmd:ConsecutiveAppendsShouldReuse

Please let me know if you have any questions.

Zeeshan Asghar