### PR TITLE
General Code Improvement 4

### DIFF
--- a/blockcanary-android/src/main/java/com/github/moduth/blockcanary/BlockCanary.java
+++ b/blockcanary-android/src/main/java/com/github/moduth/blockcanary/BlockCanary.java
@@ -25,7 +25,7 @@ import java.lang.reflect.Constructor;
  *
  * @author markzhai on 2015/9/25.
  */
-public class BlockCanary {
+public final class BlockCanary {
 
     private static final String TAG = "BlockCanary";
 

--- a/blockcanary-core/src/main/java/com/github/moduth/blockcanary/log/Block.java
+++ b/blockcanary-core/src/main/java/com/github/moduth/blockcanary/log/Block.java
@@ -32,7 +32,7 @@ import java.util.ArrayList;
 /**
  * @author markzhai on 15/9/27.
  */
-public class Block {
+public final class Block {
 
     private static final String TAG = "Block";
 

--- a/blockcanary-no-op/src/main/java/com/github/moduth/blockcanary/BlockCanary.java
+++ b/blockcanary-no-op/src/main/java/com/github/moduth/blockcanary/BlockCanary.java
@@ -18,7 +18,7 @@ import android.content.Context;
 /**
  * No-op implementation.
  */
-public class BlockCanary {
+public final class BlockCanary {
 
     private static BlockCanary sInstance = null;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S2974 Classes without 'public' constructors should be 'final'
squid:S1488 Local Variables should not be declared and then immediately returned or thrown

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2974
https://dev.eclipse.org/sonar/rules/show/squid:S1488

Please let me know if you have any questions.

Zeeshan Asghar