### PR TITLE
General Code Improvement 5

### DIFF
--- a/blockcanary-core/src/main/java/com/github/moduth/blockcanary/LogWriter.java
+++ b/blockcanary-core/src/main/java/com/github/moduth/blockcanary/LogWriter.java
@@ -35,7 +35,7 @@ public class LogWriter {
     private static final Object SAVE_DELETE_LOCK = new Object();
     private static final SimpleDateFormat FILE_NAME_FORMATTER = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss.SSS");
     private static final SimpleDateFormat TIME_FORMATTER = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-    private static final long OBSOLETE_DURATION = 2 * 24 * 3600 * 1000;
+    private static final long OBSOLETE_DURATION = 2 * 24 * 3600 * 1000L;
 
     /**
      * Save log to file

--- a/blockcanary-core/src/main/java/com/github/moduth/blockcanary/log/ProcessUtils.java
+++ b/blockcanary-core/src/main/java/com/github/moduth/blockcanary/log/ProcessUtils.java
@@ -33,7 +33,8 @@ public class ProcessUtils {
             if (sProcessName != null) {
                 return sProcessName;
             }
-            return sProcessName = obtainProcessName(BlockCanaryCore.getContext().getContext());
+            sProcessName = obtainProcessName(BlockCanaryCore.getContext().getContext());
+            return sProcessName;
         }
     }
 

--- a/demo/src/main/java/com/example/blockcanary/DemoFragment.java
+++ b/demo/src/main/java/com/example/blockcanary/DemoFragment.java
@@ -83,10 +83,12 @@ public class DemoFragment extends Fragment implements View.OnClickListener {
                 double result = compute();
                 System.out.println(result);
                 break;
+            default:
+                break;
         }
     }
 
-    private double compute() {
+    private static double compute() {
         double result = 0;
         for (int i = 0; i < 1000000; ++i) {
             result += Math.acos(Math.cos(i));
@@ -95,7 +97,7 @@ public class DemoFragment extends Fragment implements View.OnClickListener {
         return result;
     }
 
-    private void readFile() {
+    private static void readFile() {
         FileInputStream reader = null;
         try {
             reader = new FileInputStream("/proc/stat");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S2184 Math operands should be cast before assignment
squid:AssignmentInSubExpressionCheck Assignments should not be made from within sub-expressions
squid:SwitchLastCaseIsDefaultCheck 'switch' statements should end with a 'default' clause
squid:S2325 'private' methods that don't access instance data should be 'static'

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2184 
https://dev.eclipse.org/sonar/rules/show/squid:AssignmentInSubExpressionCheck 
https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck 
https://dev.eclipse.org/sonar/rules/show/squid:S2325 

Please let me know if you have any questions.

Zeeshan Asghar